### PR TITLE
Add adjacent twitter feed for pneumowatch

### DIFF
--- a/src/components/TwitterFeed.js
+++ b/src/components/TwitterFeed.js
@@ -11,7 +11,16 @@ const TwitterFeed = () => (
           In the news
         </Typography>
         <Grid container justify="center">
-          <Grid item xs={12} sm={8} md={6} lg={6}>
+          <Grid item xs={12} sm={8} md={6} lg={4}>
+            <Box p={2}>
+              <TwitterTimelineEmbed
+                sourceType="profile"
+                screenName="pneumowatch"
+                options={{ height: 400 }}
+              />
+            </Box>
+          </Grid>
+          <Grid item xs={12} sm={8} md={6} lg={4}>
             <Box p={2}>
               <TwitterTimelineEmbed
                 sourceType="profile"


### PR DESCRIPTION
Side by side twitter feeds for `@pneumowatch` and `@JunoSeq`, using the `sourceType="profile"` option for the `TwitterTimelineEmbed` component. If more handles need to be added, using `sourceType="list"` might be better (see https://developer.twitter.com/en/docs/twitter-for-websites/timelines/overview). Discussed with Christine.